### PR TITLE
feat: adding support for notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "UT bus module",
   "dependencies": {
     "browser-process-hrtime": "0.1.2",
-    "joi": "10.0.1",
+    "joi": "10.0.6",
     "lodash.assign": "4.2.0",
     "lodash.capitalize": "4.2.1",
     "readable-stream": "2.1.4",


### PR DESCRIPTION
This includes a list of imrpovements and fixes:
- frames are logged as mtid:frame, opcode: in/out
- fixed promises lint errors
- return promises when not using socket (usually there is no socket during automated tests)
- added bus.notification method, that invokes methods, withoud waiting for response
- proper dispatching of notifications
- pass config to logger from port.log property
- port start/stop are now logged with mtid=event
- port send/receive hooks are now invoked with (msg, $meta, context) parameters
- proper handling of notifications for ports using pipeReverse
- added logging of errors that may happen during dispatch