### PR TITLE
feat: refactor reuse code between start and stop methods. Add ready event.

### DIFF
--- a/port.js
+++ b/port.js
@@ -8,7 +8,7 @@ var bufferCreate = Buffer;
 var assign = require('lodash.assign');
 var hrtime = require('browser-process-hrtime');
 var errors = require('./errors');
-var systemEvents = ['start', 'stop', 'ready'];
+var systemEvents = ['start', 'ready'];
 
 function handleStreamClose(stream, conId, done) {
     if (stream) {
@@ -172,6 +172,14 @@ systemEvents.forEach(function(event) {
         return triggerEvent.call(this, event);
     };
 });
+
+Port.prototype.stop = function stop() {
+    return triggerEvent.call(this, 'stop')
+        .then(() => {
+            this.streams.forEach(stream => stream.end());
+            return true;
+        });
+};
 
 Port.prototype.request = function request() {
     var port = this;


### PR DESCRIPTION
Prepare ready event to be invoked by ut-run right after port.start resolves. Could be convinient for example in sql port to have a handler which could be executed once all schema scripts have been initialized