### PR TITLE
fix: make busMethod to unpack messages by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ module.exports = function Bus() {
         getMethod: function(typeName, methodType, methodName, options) {
             var bus = this;
             var fn = null;
-            var unpack = false;
+            var unpack = true;
             var fallback = options && options.fallback;
             var timeoutSec = options && options.timeout && (Math.floor(options.timeout / 1000));
             var timeoutNSec = options && options.timeout && (options.timeout % 1000 * 1000000);


### PR DESCRIPTION
make busMethod to unpack messages by default