### PR TITLE
fix: name resolving

### DIFF
--- a/jsonrpc.js
+++ b/jsonrpc.js
@@ -61,7 +61,7 @@ module.exports = async function create({id, socket, channel, logLevel, logger, m
                     if (resolver) {
                         return resolver.resolveSrv(params.host + '-' + domain + '.dns-discovery.local')
                             .then(result => {
-                                params.host = result.target;
+                                params.host = (this.config.nameResolving && params.host) || result.target;
                                 params.port = result.port;
                                 return params;
                             });


### PR DESCRIPTION
when process runs in docker resolved ip is always 0.0.0.0, but in different container, since containers can be pointed by name this patch will handle name resolving