### PR TITLE
fix: improve swagger config structure

### DIFF
--- a/jsonrpc.js
+++ b/jsonrpc.js
@@ -20,8 +20,8 @@ module.exports = async function create({id, socket, channel, logLevel, logger, m
         logger && logger.info && logger.info({$meta: {mtid: 'event', method: 'jsonrpc.listen'}, serverInfo: server.info});
     });
 
-    const swagger = (socket.swagger || socket.swaggerUi) && await require('./swagger')(socket.swagger, errors);
-    const swaggerUi = swagger && socket.swaggerUi && require('./swagger/ui')(swagger.document);
+    const swagger = socket.swagger && await require('./swagger')(socket.swagger.document, errors);
+    const swaggerUi = swagger && socket.swagger.ui && require('./swagger/ui')(swagger.document, socket.swagger.ui);
 
     if (swaggerUi) server.route(swaggerUi.routes);
 

--- a/swagger/ui.js
+++ b/swagger/ui.js
@@ -1,7 +1,5 @@
 const fs = require('fs');
 const uiDistPath = require('swagger-ui-dist').getAbsoluteFSPath();
-const uiTitle = 'Swagger UI';
-const uiPath = '/docs';
 const html = (title, path) => `
 <!DOCTYPE html>
 <html lang="en">
@@ -106,31 +104,34 @@ window.onload = function() {
 </html>
 `;
 
-module.exports = swaggerDocument => {
+module.exports = (swaggerDocument, {
+    title = 'Swagger UI',
+    path = '/docs'
+}) => {
     return {
         routes: [
             {
-                path: uiPath,
-                response: html(uiTitle, uiPath),
+                path,
+                response: html(title, path),
                 type: 'text/html'
             },
             {
-                path: uiPath + '/api-docs',
+                path: path + '/api-docs',
                 response: swaggerDocument,
                 type: 'application/json'
             },
             {
-                path: uiPath + '/swagger-ui-bundle.js',
+                path: path + '/swagger-ui-bundle.js',
                 response: fs.readFileSync(uiDistPath + '/swagger-ui-bundle.js'),
                 type: 'application/json'
             },
             {
-                path: uiPath + '/swagger-ui-standalone-preset.js',
+                path: path + '/swagger-ui-standalone-preset.js',
                 response: fs.readFileSync(uiDistPath + '/swagger-ui-standalone-preset.js'),
                 type: 'application/json'
             },
             {
-                path: uiPath + '/swagger-ui.css',
+                path: path + '/swagger-ui.css',
                 response: fs.readFileSync(uiDistPath + '/swagger-ui.css'),
                 type: 'text/css'
             }


### PR DESCRIPTION
Improve swagger configuration format. Example configuration.

```json
{
    "utBus": {
        "serviceBus": {
            "jsonrpc": {
                "swagger": {
                    "document": "/path/to/document",
                    "ui": {
                        "title": "Swagger Ui Title",
                        "path": "/docs"
                    }
                }
            }
        }
    }
}
```

In order to disable the swagger ui then the `ui` property can be omitted or set to a falsey value like `false` or `null`. E.g: 

```json
{
    "utBus": {
        "serviceBus": {
            "jsonrpc": {
                "swagger": {
                    "document": "/path/to/document",
                    "ui": false
                }
            }
        }
    }
}
```

if no special configuration is needed for the UI but it should still be enabled, then the following configuration can be provided:
```json
{
    "utBus": {
        "serviceBus": {
            "jsonrpc": {
                "swagger": {
                    "document": "/path/to/document",
                    "ui": true
                }
            }
        }
    }
}
```

if there are no custom routes then the `document` property can be omitted:

```json
{
    "utBus": {
        "serviceBus": {
            "jsonrpc": {
                "swagger": {
                    "ui": true
                }
            }
        }
    }
}
```