### PR TITLE
feat: prepare api gateway capabilities

### DIFF
--- a/broker.js
+++ b/broker.js
@@ -61,7 +61,8 @@ class Broker {
                     this.log && this.log.error && this.log.error(error);
                     return '';
                 }
-            }
+            },
+            ...this.registerLocal && {registerLocal: (...params) => this.registerLocal(...params)}
         });
         return this.rpc;
     }

--- a/jsonrpc.js
+++ b/jsonrpc.js
@@ -36,7 +36,7 @@ const openIdUrl = url => {
     return url;
 };
 
-module.exports = async function create({id, socket, channel, logLevel, logger, mapLocal, errors, findMethodIn, metrics, service}) {
+module.exports = async function create({id, socket, channel, logLevel, logger, mapLocal, errors, findMethodIn, metrics, service, registerLocal}) {
     const server = new hapi.Server({
         port: socket.port
     });
@@ -80,7 +80,10 @@ module.exports = async function create({id, socket, channel, logLevel, logger, m
     });
 
     const utApi = socket.api && await require('ut-api')({service, oidc, auth: socket.openId ? 'openId' : false, ...socket.api}, errors);
-    if (utApi && utApi.uiRoutes) server.route(utApi.uiRoutes);
+    if (utApi) {
+        if (utApi.uiRoutes) server.route(utApi.uiRoutes);
+        if (registerLocal && utApi.modules) Object.entries(utApi.modules).forEach(([moduleName, methods]) => registerLocal(methods, moduleName));
+    };
 
     server.route([{
         method: 'GET',


### PR DESCRIPTION
Features included:
* pass registerLocal to jsonrpc
* register utApi modules locally if available

This would allow utApi to register handlers in http server ports.

![image](https://user-images.githubusercontent.com/6398208/68785356-be652b00-0646-11ea-97b4-7581fa81e185.png)
